### PR TITLE
Enhancement: add topic for takeoff registration and remove requirement for service call

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ corresponding paper and consult the `LICENSE` file for a detailed explanation.
 
 ## Getting Started
 
-### Prerequesites
+### Prerequisites
 This package is part of the [CNS Flight Stack] and thus depends on the other packages of the flight stack:
 - [CNS Flight Stack: Autonomy Engine]
 
 
-Further the following libraries are required
+Further, the following libraries are required
 - Eigen
 - ROS noetic
 
@@ -71,7 +71,8 @@ The following parameters can be set to modify the detector's behavior:
 | `R_IP`                    | rotation calibration between IMU and "body" frame | Identity Matrix |
 | `R_LP`                    | rotation calibration between "body" frame and range sensor | Identity Matrix |
 | `t_LP`                    | translation calibration between "body" frame and range sensor | Zero Vector |
-| `lrf_use_median`          | automatic state changes in sequencer (if used without Autonomy Engine) | `false` |
+| `use_median`              | use the median rather than the mean for LRF-based caluclation | `false` |
+| `require_srv_call`        | require a service call before any takeoff is detected | `false` |
 | `imu_topic`               | ROS topic name for the IMU measurements | `/imu` |
 | `lrf_topic`               | ROS topic name for the range measurements | `/lrf` |
 | `baro_topic`              | ROS topic name for the barometric measurements | `/baro` |
@@ -88,7 +89,7 @@ roslaunch toland_flight toland.launch <PARAM1_NAME>:=<VALUE> <PARAM2_NAME>:=<VAL
 | `default_sensor`          | default AGL sensor to use (`lrf`, `baro`, or `disabled`) | `lrf` |
 | `imu_topic`               | ROS topic name for the IMU measurements  | `/imu` |
 | `lrf_topic`               | ROS topic name for the range measurements  | `/lrf` |
-| `baro_topic`               | ROS topic name for the barometric measurements  | `/baro` |
+| `baro_topic`              | ROS topic name for the barometric measurements  | `/baro` |
 | `R_IP`                    | rotation calibration between IMU and "body" frame | Identity Matrix |
 | `R_PL`                    | rotation calibration between "body" frame and range sensor | Identity Matrix |
 | `t_PL`                    | translation calibration between "body" frame and range sensor | Zero Vector |
@@ -96,7 +97,8 @@ roslaunch toland_flight toland.launch <PARAM1_NAME>:=<VALUE> <PARAM2_NAME>:=<VAL
 | `angle_threshold`         | threshold in [deg] acceptable as flat (gravity-aligned check) | `10.0` |
 | `distance_threshold`      | threshold in [m] acceptable as on the ground (height check) | `0.15` |
 | `takeoff_theshold`        | threshold in [m] upon which a successful takeoff is registered | `0.5` |
-| `lrf_use_median`          | use the median rather than the mean for LRF-based caluclation | `false` |
+| `use_median`              | use the median rather than the mean for LRF-based caluclation | `false` |
+| `require_srv_call`        | require a service call before any takeoff is detected | `true` |
 
 ### Usage without Autonomy Engine
 
@@ -111,9 +113,14 @@ message: "number of measurements -- IMU: x -- LRF: x -- BARO: x"
 
 If this service was called once, you will receive a message on the `/toland/is_landed` topic, if a landing was detected. In order for this to happen, the UAV must have taken off successfully (`dist>takeoff_theshold`). Please note that for this feature a **range sensor must be used**.
 
+In case you do not want to execute the service call, you can deactivate it by launching
+```bash
+roslaunch toland_flight toland.launch require_srv_call:=False
+```
+
 ## Architecture
 
-Please refer to the academic paper for further insights of the Takeoff and Landing Detector.
+Please refer to the academic paper for further insights into the Takeoff and Landing Detector.
 
 
 ## Known Issues
@@ -121,20 +128,20 @@ Please refer to the academic paper for further insights of the Takeoff and Landi
 #### Landing Detection Message only transmitted once
 The current implementation only transmits a landing detection message once. There it does not check for flatness (as it should not). However, when you then request via the provided service if the vehicle is on the ground, it might return `false` as the flatness (gravity-aligned) condition might not be met.
 
-We are working on this issue, which requires modification also on the [CNS Flight Stack: Autonomy Engine].
+We are working on this issue, which also requires modification in the [CNS Flight Stack: Autonomy Engine].
 
 #### Barometer triggers landing detection early
-This is due to inaccurate barometric measurements (especially indoors) before flight. The current initialization routine sets the reference pressure at startup using the mean of the first 100 measurements. If between startup external influences (even start of the motors) would change the reference pressure, technically a restart of the node is currently required.
+This is due to inaccurate barometric measurements (especially indoors) before flight. The current initialization routine sets the reference pressure at startup using the mean of the first 100 measurements. If between startup external influences (even the start of the motors) would change the reference pressure, technically a restart of the node is currently required.
 
-This issue is also WIP, but can be circumvent by using a more accurate AGL sensor.
+This issue is also WIP but can be circumvented by using a more accurate AGL sensor.
 
 ## Package Layout
 
 ```console
 /path/to/to_landing_detector$ tree -L 3 --noreport --charset unicode
 .
-|-- CHANGELOG.md
 |-- CMakeLists.txt
+|-- CONTRIBUTORS.md
 |-- include
 |   |-- toland_flight
 |   |   `-- FlightDetector.hpp

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ The following parameters can be set to modify the detector's behavior:
 | `t_LP`                    | translation calibration between "body" frame and range sensor | Zero Vector |
 | `use_median`              | use the median rather than the mean for LRF-based caluclation | `false` |
 | `require_srv_call`        | require a service call before any takeoff is detected | `false` |
-| `imu_topic`               | ROS topic name for the IMU measurements | `/imu` |
-| `lrf_topic`               | ROS topic name for the range measurements | `/lrf` |
-| `baro_topic`              | ROS topic name for the barometric measurements | `/baro` |
+| `imu_topic`               | ROS topic name for the IMU measurements | `~imu` |
+| `lrf_topic`               | ROS topic name for the range measurements | `~lrf` |
+| `baro_topic`              | ROS topic name for the barometric measurements | `~baro` |
 
 ### Default Launchfile Parameters
 
@@ -87,9 +87,9 @@ roslaunch toland_flight toland.launch <PARAM1_NAME>:=<VALUE> <PARAM2_NAME>:=<VAL
 | Launch parameter | description | default value |
 |---------------|-------------|---------------|
 | `default_sensor`          | default AGL sensor to use (`lrf`, `baro`, or `disabled`) | `lrf` |
-| `imu_topic`               | ROS topic name for the IMU measurements  | `/imu` |
-| `lrf_topic`               | ROS topic name for the range measurements  | `/lrf` |
-| `baro_topic`              | ROS topic name for the barometric measurements  | `/baro` |
+| `imu_topic`               | ROS topic name for the IMU measurements  | `~imu` |
+| `lrf_topic`               | ROS topic name for the range measurements  | `~lrf` |
+| `baro_topic`              | ROS topic name for the barometric measurements  | `~baro` |
 | `R_IP`                    | rotation calibration between IMU and "body" frame | Identity Matrix |
 | `R_PL`                    | rotation calibration between "body" frame and range sensor | Identity Matrix |
 | `t_PL`                    | translation calibration between "body" frame and range sensor | Zero Vector |

--- a/include/toland_flight/FlightDetector.hpp
+++ b/include/toland_flight/FlightDetector.hpp
@@ -105,7 +105,7 @@ private:
   std::atomic<bool> f_have_lrf_{ false };       //!< flag to determine if LRF measurement was received
   std::atomic<bool> f_have_baro_{ false };      //!< flag to determine if baro measurement was received
   std::atomic<bool> f_have_P0_{ false };        //!< flag to determine if baro was initialized
-  std::atomic<bool> f_reqested_to_{ false };    //!< flag to determine if takeoff has been requested (once)
+  std::atomic<bool> f_requested_to_{ false };   //!< flag to determine if takeoff has been requested (once)
   std::atomic<bool> f_successful_to_{ false };  //!< flag to determine if takeoff has succeeded
   Sensor sensor_{ Sensor::UNDEFINED };
 

--- a/include/toland_flight/FlightDetector.hpp
+++ b/include/toland_flight/FlightDetector.hpp
@@ -85,28 +85,28 @@ private:
   std::vector<ImuData_t> imu_data_buffer_;    //!< buffer for IMU measurements
   std::vector<LrfData_t> lrf_data_buffer_;    //!< buffer for LRF measurements
   std::vector<BaroData_t> baro_data_buffer_;  //!< buffer for BARO measurements
-  double takeoff_start_time{ 0.0 };
+  double takeoff_start_time_{ 0.0 };
 
   /// ROS Static Parameters
   double k_sensor_readings_window_s_{ 1.0 };  //!< buffer time
   double k_angle_threshold_deg_{ 10.0 };      //!< threshold for gravity direction in [deg]
   double k_distance_threshold_m_{ 0.1 };      //!< threshold for distance in [m]
   double k_takeoff_threshold_m_{ 0.5 };       //!< threshold for takeoff in [m]
-  std::vector<double> k_R_IP = { 1, 0, 0, 0, 1, 0, 0, 0, 1 };
-  std::vector<double> k_R_PL = { 1, 0, 0, 0, 1, 0, 0, 0, 1 };
-  std::vector<double> k_t_PL = { 0, 0, 0 };
-  double k_landed_wait_time = { 30.0 };
+  std::vector<double> k_R_IP_ = { 1, 0, 0, 0, 1, 0, 0, 0, 1 };
+  std::vector<double> k_R_PL_ = { 1, 0, 0, 0, 1, 0, 0, 0, 1 };
+  std::vector<double> k_t_PL_ = { 0, 0, 0 };
+  double k_landed_wait_time_ = { 30.0 };
   bool k_use_median_ = { false };  //!< determines if the SENSOR distance calculations use median or mean
   bool k_is_playback_{ false };    //!< determines if a playback is active (used for debugging)
   bool k_require_srv_{ true };     //!< determines if a service call has to be performed befor any topic publication
 
   /// Internal Flags
-  std::atomic<bool> f_have_imu_{ false };      //!< flag to determine if IMU measurement was received
-  std::atomic<bool> f_have_lrf_{ false };      //!< flag to determine if LRF measurement was received
-  std::atomic<bool> f_have_baro_{ false };     //!< flag to determine if baro measurement was received
-  std::atomic<bool> f_have_P0_{ false };       //!< flag to determine if baro was initialized
-  std::atomic<bool> f_reqested_to{ false };    //!< flag to determine if takeoff has been requested (once)
-  std::atomic<bool> f_successful_to{ false };  //!< flag to determine if takeoff has succeeded
+  std::atomic<bool> f_have_imu_{ false };       //!< flag to determine if IMU measurement was received
+  std::atomic<bool> f_have_lrf_{ false };       //!< flag to determine if LRF measurement was received
+  std::atomic<bool> f_have_baro_{ false };      //!< flag to determine if baro measurement was received
+  std::atomic<bool> f_have_P0_{ false };        //!< flag to determine if baro was initialized
+  std::atomic<bool> f_reqested_to_{ false };    //!< flag to determine if takeoff has been requested (once)
+  std::atomic<bool> f_successful_to_{ false };  //!< flag to determine if takeoff has succeeded
   Sensor sensor_{ Sensor::UNDEFINED };
 
   /// Barometer Parameters

--- a/include/toland_flight/FlightDetector.hpp
+++ b/include/toland_flight/FlightDetector.hpp
@@ -78,7 +78,8 @@ private:
 
   ros::ServiceServer srv_to_;  //!< Takeoff service
 
-  ros::Publisher pub_land_;  //!< publishes
+  ros::Publisher pub_land_;  //!< publishes a message upon registering a landing
+  ros::Publisher pub_to_;    //!< publishes a message upon registering a takeoff
 
   /// Measurement buffers
   std::vector<ImuData_t> imu_data_buffer_;    //!< buffer for IMU measurements

--- a/include/toland_flight/FlightDetector.hpp
+++ b/include/toland_flight/FlightDetector.hpp
@@ -97,6 +97,7 @@ private:
   double k_landed_wait_time = { 30.0 };
   bool k_use_median_ = { false };  //!< determines if the SENSOR distance calculations use median or mean
   bool k_is_playback_{ false };    //!< determines if a playback is active (used for debugging)
+  bool k_require_srv_{ true };     //!< determines if a service call has to be performed befor any topic publication
 
   /// Internal Flags
   std::atomic<bool> f_have_imu_{ false };      //!< flag to determine if IMU measurement was received

--- a/launch/toland.launch
+++ b/launch/toland.launch
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) 2022 Martin Scheiber and Alessandro Fortnasier,
+  Copyright (C) 2022-2023 Martin Scheiber and Alessandro Fortnasier,
   Control of Networked Systems, University of Klagenfurt, Austria.
 
   All rights reserved.
@@ -14,10 +14,10 @@
 -->
 <launch>
   <!-- rostopic strings -->
-  <arg name="imu_topic" default="/imu" />   <!-- Mandatory -->
-  <arg name="lrf_topic" default="/lrf" />   <!-- LRF is used as primary sensor, if toic is undefined it will fallback to baro -->
-  <arg name="baro_topic" default="/baro" /> <!-- BARO used if LRF is not defined -->
-  <arg name="default_sensor" default="lrf" />
+  <arg name="imu_topic"       default="/imu" />   <!-- Mandatory -->
+  <arg name="lrf_topic"       default="/lrf" />   <!-- LRF is used as primary sensor, if toic is undefined it will fallback to baro -->
+  <arg name="baro_topic"      default="/baro" />  <!-- BARO used if LRF is not defined -->
+  <arg name="default_sensor"  default="lrf" />
 
   <!-- calibration parameters -->
   <arg name="R_IP"      default="[1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]" />
@@ -31,6 +31,7 @@
   <arg name="takeoff_theshold"        default="0.5" />
   <arg name="use_median"              default="false" />
   <arg name="playback"                default="false" />
+  <arg name="require_srv_call"        default="true" />
 
 
   <node name="toland_detector" pkg="to_landing_detector" type="toland_node" output="screen" respawn="true" clear_params="true">
@@ -47,6 +48,7 @@
     <param name="takeoff_theshold"        type="double" value="$(arg takeoff_theshold)" />
     <param name="use_median"              type="bool"   value="$(arg use_median)" />
     <param name="playback"                type="bool"   value="$(arg playback)" />
+    <param name="require_srv_call"        type="bool"   value="$(arg require_srv_call)" />
 
     <!-- calibration parameters -->
     <rosparam param="R_PI" subst_value="true">$(arg R_IP)</rosparam>

--- a/launch/toland.launch
+++ b/launch/toland.launch
@@ -14,9 +14,9 @@
 -->
 <launch>
   <!-- rostopic strings -->
-  <arg name="imu_topic"       default="/imu" />   <!-- Mandatory -->
-  <arg name="lrf_topic"       default="/lrf" />   <!-- LRF is used as primary sensor, if toic is undefined it will fallback to baro -->
-  <arg name="baro_topic"      default="/baro" />  <!-- BARO used if LRF is not defined -->
+  <arg name="imu_topic"       default="imu" />   <!-- Mandatory -->
+  <arg name="lrf_topic"       default="lrf" />   <!-- LRF is used as primary sensor, if toic is undefined it will fallback to baro -->
+  <arg name="baro_topic"      default="baro" />  <!-- BARO used if LRF is not defined -->
   <arg name="default_sensor"  default="lrf" />
 
   <!-- calibration parameters -->

--- a/src/FlightDetector.cpp
+++ b/src/FlightDetector.cpp
@@ -122,7 +122,7 @@ FlightDetector::FlightDetector() : nh_("toland_detector")
   srv_to_ = nh_.advertiseService("service/takeoff", &FlightDetector::takeoffHandler, this);
 
   // update 'f_requested_to' based on requirement to servicec call
-  f_reqested_to_ = !k_require_srv_;
+  f_requested_to_ = !k_require_srv_;
   takeoff_start_time_ = ros::Time::now().toSec();
 }  // FlightDetector()
 
@@ -226,7 +226,7 @@ bool FlightDetector::takeoffHandler(std_srvs::Trigger::Request& req, std_srvs::T
   res.message = res_msg;
 
   // setup request takeof
-  f_reqested_to_ = !k_require_srv_ || is_sucess;
+  f_requested_to_ = !k_require_srv_ || is_sucess;
   takeoff_start_time_ = ros::Time::now().toSec();
 
 #ifndef NDEBUG
@@ -443,7 +443,7 @@ double FlightDetector::calculateDistance()
 void FlightDetector::publishLanded()
 {
   // publish landed message if below threshold
-  if (f_reqested_to_)
+  if (f_requested_to_)
   {
     ROS_DEBUG_STREAM("> checking if LANDED");
 

--- a/src/FlightDetector.cpp
+++ b/src/FlightDetector.cpp
@@ -116,6 +116,7 @@ FlightDetector::FlightDetector() : nh_("toland_detector")
 
   // setup publishers
   pub_land_ = nh_.advertise<std_msgs::Bool>("is_landed", 1);
+  pub_to_ = nh_.advertise<std_msgs::Bool>("is_takeoff", 1);
 
   // setup services
   srv_to_ = nh_.advertiseService("service/takeoff", &FlightDetector::takeoffHandler, this);
@@ -462,6 +463,11 @@ void FlightDetector::publishLanded()
 
       if (dist > k_takeoff_threshold_m_)
       {
+        // setup message
+        std_msgs::Bool msg;
+        msg.data = true;  // INFO(scm): no real information to set here atm
+        pub_to_.publish(msg);
+
         f_successful_to = true;
         ROS_DEBUG("Successfully taken off.");
       }


### PR DESCRIPTION
This PR enhances the takeoff_landing detector by

- adding a parameter to disable the requirement to perform the service call
- adding a topic for publishing when a takeoff has been registered
- performing some QoL improvements (code standardization,